### PR TITLE
Updated the base image to conchoid/docker-phpenv:v1-14-7.4-stretch.

### DIFF
--- a/7.4-stretch/Dockerfile
+++ b/7.4-stretch/Dockerfile
@@ -1,4 +1,4 @@
-FROM conchoid/docker-phpenv:v1-13-7.4-stretch
+FROM conchoid/docker-phpenv:v1-14-7.4-stretch
 
 ENV PHP_CONFIGURE_OPTS "--disable-fpm --disable-cgi"
 ENV PHP_AUTOCONF /usr/bin/autoconf
@@ -7,9 +7,9 @@ ENV PHP_AUTOCONF /usr/bin/autoconf
 # https://www.php.net/supported-versions.php
 ENV PREINSTALLED_VERSIONS "\
 7.1.33\n\
-7.2.27\n\
-7.3.14\n\
-7.4.2"
+7.2.34\n\
+7.3.24\n\
+7.4.12"
 
 RUN phpenv global system \
     && system_php_ver=$(php -v | head -1 | sed -e "s/^PHP \([0-9.]*\).*$/\1/") \


### PR DESCRIPTION
データ量削減に伴いベースイメージをライブラリを変更した`conchoid/docker-phpenv:v1-14-7.4-stretch`へ切り替えました。
上記でphp-buildが更新されたので `PREINSTALLED_VERSIONS `をアップデートしました。

docker imageは `conchoid/docker-phpenv-builtins:v1-14-7.4-stretch`のタグ名でdocker hubへpushしました。

関連するPR
https://github.com/conchoid/docker-phpenv/pull/5